### PR TITLE
Update spare to 1.2.4 | v1.2.3 will be yanked from PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please open an issue if you find any bugs for the newer versions of spare_score
 ## Usage
 
 ```text
-spare_scores  v1.2.3.
+spare_scores  v1.2.4
 SPARE model training & scores calculation
 required arguments:
         [ACTION]        The action to be performed, either 'train' or 'test'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="spare_scores",
-    version="1.2.3",
+    version="1.2.4",
     description="Compute characteristic brain signatures of your case population.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
**v1.2.3 must be yanked from PyPI as macos wheels fail for python 3.12**
